### PR TITLE
添加后端两个服务

### DIFF
--- a/app.py
+++ b/app.py
@@ -53,6 +53,31 @@ def chat():
 def donate():
     return render_template('supportme.html')
 
+@app.route('/completion')
+def completion():
+    user_input = request.form.get('user_input')
+    if not user_input:
+        return {'code': 1, 'data': 'user_input can not be empty'}
+
+    chat_history = session['chat_history']
+    chat_history.append(('User', user_input))  # 存储用户输入
+
+    context = session['context_history']
+    context.append({'role': 'user', 'content': f"{user_input}"})
+
+    response = OpenAIUtils.get_completion_from_messages(context)
+
+    context.append({'role': 'assistant', 'content': f"{response}"})
+    chat_history.append(('AI', response))  # 存储AI回答
+
+    return {'code': 0, 'data': response}
+
+@app.route('/chat-history')
+def chat_history():
+    chat_history = session['chat_history']
+    return {'code': 0, 'data': chat_history}
+
+
 # @socketio.on('connect', namespace='/chat')
 # def test_connect():
 #     global online_users


### PR DESCRIPTION
添加了后端的两个服务：

- `/completion` 完成 OpenAI 接口调用。
- `/chat-history` 获取当前的聊天记录。

--------------------

你说的功能，要做以下改动：

- 后端和前端的一些功能，需要分离。而不是使用后端模板直接渲染。
- 后端需要的功能，就是我这个 PR 加了。
- 前端做的事，1. 页面加载时通过 /chat-history 获取当前记录。 2. 点击按钮之后，通过 /completion 完成调用并更新数据。
- 前端维护一套自己的 "chat history"的基础之上，才可以做说你的那两个功能。
